### PR TITLE
Issue 47 empty qv txt and tv txt produced

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For example, if some rows in the input worksheet had the value 'heaf_17_fup4' fo
  
 ## DV mappings file
 
-The following column headers must be present in the first worksheet in the input Excel file, in order to create the dv text files:
+The following column headers must be present in the second worksheet in the input Excel file, in order to create the dv text files:
 
  - Dataset prefix
  - Derived variable name

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
               ['dataset prefix', 'variable name', 'topic id'],
               `${datasetPrefix}_tv.txt`)
 
-            addLinkToNewDiv(tvLinkURL,
+            !!tvLinkUrl && addLinkToNewDiv(tvLinkURL,
               `${datasetPrefix}_tv.txt`,
               `${datasetPrefix}_tv.txt`,
               `tv${datasetPrefix.replaceAll("_", "-")}`)
@@ -254,7 +254,7 @@
               `${questionnairePrefix}_tq.txt`,
               { 'questionnaire prefix': '_ccs01' })
 
-            addLinkToNewDiv(tqLinkURL,
+            !!tqLinkUrl && addLinkToNewDiv(tqLinkURL,
               `${questionnairePrefix}_tq.txt`,
               `${questionnairePrefix}_tq.txt`,
               `tq${questionnairePrefix.replaceAll("_", "-")}`)
@@ -284,7 +284,7 @@
             ],
               `${datasetPrefix}_dv.txt`)
 
-            addLinkToNewDiv(dvLinkURL,
+            !!dvLinkUrl && addLinkToNewDiv(dvLinkURL,
               `${datasetPrefix}_dv.txt`,
               `${datasetPrefix}_dv.txt`,
               `dv${datasetPrefix.replaceAll("_", "-")}`)

--- a/index.html
+++ b/index.html
@@ -131,7 +131,9 @@
 
       var formBlob = new Blob([fileData], { type: 'text/plain' });
 
-      zip.file(fileName, fileData);
+      if (formBlob.size > 0)
+
+          zip.file(fileName, fileData);
 
       const downloadLink = window.URL.createObjectURL(formBlob);
 
@@ -173,11 +175,13 @@
 
     function handleFiles(fileList) {
 
-      document.getElementById("fileLinks").innerHTML = ""
-
       const reader = new FileReader()
 
       reader.onload = (function (event) {
+
+        document.getElementById("fileLinks").innerHTML = ""
+
+        document.getElementById("downloadAllFiles").innerHTML = ""
 
         try {
 
@@ -226,7 +230,7 @@
               ['dataset prefix', 'variable name', 'topic id'],
               `${datasetPrefix}_tv.txt`)
 
-            !!tvLinkUrl && addLinkToNewDiv(tvLinkURL,
+            !!tvLinkURL && addLinkToNewDiv(tvLinkURL,
               `${datasetPrefix}_tv.txt`,
               `${datasetPrefix}_tv.txt`,
               `tv${datasetPrefix.replaceAll("_", "-")}`)
@@ -254,7 +258,7 @@
               `${questionnairePrefix}_tq.txt`,
               { 'questionnaire prefix': '_ccs01' })
 
-            !!tqLinkUrl && addLinkToNewDiv(tqLinkURL,
+            !!tqLinkURL && addLinkToNewDiv(tqLinkURL,
               `${questionnairePrefix}_tq.txt`,
               `${questionnairePrefix}_tq.txt`,
               `tq${questionnairePrefix.replaceAll("_", "-")}`)
@@ -284,10 +288,11 @@
             ],
               `${datasetPrefix}_dv.txt`)
 
-            !!dvLinkUrl && addLinkToNewDiv(dvLinkURL,
+            dvLinkURL && addLinkToNewDiv(dvLinkURL,
               `${datasetPrefix}_dv.txt`,
               `${datasetPrefix}_dv.txt`,
               `dv${datasetPrefix.replaceAll("_", "-")}`)
+              
           })
 
         } catch (error) {
@@ -300,16 +305,24 @@
         `
         }
 
-        zip.generateAsync({ type: "blob" })
-          .then(function (content) {
-            const downloadLink = window.URL.createObjectURL(content);
-            addLinkToExistingDiv(downloadLink,
-              "allMappings.zip",
-              "allMappings.zip",
-              "downloadAllFiles",
-              "Click the link below to download all the generated mapping files.")
-
+        if (Object.keys(zip.files).length > 0) {
+          zip.generateAsync({ type: "blob" })
+            .then(function (content) {
+              const downloadLink = window.URL.createObjectURL(content);
+              addLinkToExistingDiv(downloadLink,
+                "allMappings.zip",
+                "allMappings.zip",
+                "downloadAllFiles",
+                "Click the link below to download all the generated mapping files.")
           });
+        }
+
+        else {
+
+          document.getElementById("downloadAllFiles")
+            .innerHTML = "Insufficient data in input spreadsheet to generate any mapping files."
+          
+        }
 
       })
 

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
         columns.map(columnName => rowValues.push(worksheetRow[columnName.toLowerCase()]
           + (!!suffix[columnName] ? suffix[columnName] : "")))
 
-        const lowerCaseRowValues = rowValues.map(rowValue => rowValue.toLowerCase())
+        const lowerCaseRowValues = rowValues.map(rowValue => rowValue.trim().toLowerCase())
 
         if (!(lowerCaseRowValues.includes("n/a") || lowerCaseRowValues.includes("na") || lowerCaseRowValues.includes("derived") || lowerCaseRowValues.includes("")))
           fileData = fileData + rowValues.join("\t") + "\n"
@@ -194,14 +194,14 @@
           worksheetRow => worksheetRow['dataset prefix']).filter(datasetPrefixCell =>
             (!!datasetPrefixCell && !(datasetPrefixCell.toLowerCase().includes("n/a") 
             || datasetPrefixCell.toLowerCase().includes("na") 
-            || datasetPrefixCell.toLowerCase().includes("derived") || !datasetPrefixCell))
+            || datasetPrefixCell.toLowerCase().includes("derived") || !datasetPrefixCell.trim()))
         )))
 
         var questionnairePrefixes = (getUniqueArrayValues(qvTvWorksheetOrderedByRows.map(
           worksheetRow => worksheetRow['questionnaire prefix']).filter(questionnairePrefixCell =>
             (!!questionnairePrefixCell && !(questionnairePrefixCell.toLowerCase().includes("n/a") 
             || questionnairePrefixCell.toLowerCase().includes("na") 
-            || questionnairePrefixCell.toLowerCase().includes("derived") || !questionnairePrefixCell))
+            || questionnairePrefixCell.toLowerCase().includes("derived") || !questionnairePrefixCell.trim()))
         )))
 
           questionnairePrefixes.forEach(questionnairePrefix => {
@@ -272,7 +272,7 @@
           (!!datasetPrefixCell 
           && !(datasetPrefixCell.toLowerCase().includes("n/a") 
           || datasetPrefixCell.toLowerCase().includes("na") 
-          || datasetPrefixCell.toLowerCase().includes("derived") || !datasetPrefixCell))
+          || datasetPrefixCell.toLowerCase().includes("derived") || !datasetPrefixCell.trim()))
         )))
 
           datasetPrefixes.forEach(datasetPrefix => {

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
 
       const downloadLink = window.URL.createObjectURL(formBlob);
 
-      return downloadLink
+      return formBlob.size > 0 ? downloadLink : null
 
     }
 
@@ -212,7 +212,7 @@
               `${questionnairePrefix}_qv.txt`,
               { 'questionnaire prefix': '_ccs01' })
 
-            addLinkToNewDiv(qvLinkURL,
+            !!qvLinkURL && addLinkToNewDiv(qvLinkURL,
               `${questionnairePrefix}_qv.txt`,
               `${questionnairePrefix}_qv.txt`,
               `qv${questionnairePrefix.replaceAll("_", "-")}`)


### PR DESCRIPTION
Improve error handling/reporting for cases where insufficient information is available in input spreadsheet to create output files.

Add error-catching code so we don't show empty files in cases where there is enough info in the input spreadsheet to create the ouput files, but not to populate them.

Add trim commands to code which gets values of worksheet cells; deals with issues caused by cells containing nothing but whitespace.